### PR TITLE
Make `K ->> V` an opaque type of `V`

### DIFF
--- a/core/shared/src/main/scala-3/formless/hlist/HList.scala
+++ b/core/shared/src/main/scala-3/formless/hlist/HList.scala
@@ -87,6 +87,9 @@ object HList {
 
   def fromArray[A](a: Array[A]): HList = a.foldRight(HNil: HList)(_ :: _)
 
+  type Head[H <: HList] = H match { case h :: _ => h }
+  type Tail[H <: HList] = H match { case _ :: t => t }
+
   type FromTuple[T <: Tuple] <: HList = T match {
     case EmptyTuple => HNil
     case h *: t => h :: FromTuple[t]

--- a/core/shared/src/main/scala-3/formless/record/RecordPackageCompat.scala
+++ b/core/shared/src/main/scala-3/formless/record/RecordPackageCompat.scala
@@ -5,16 +5,20 @@ import formless.hlist.HList
 import scala.language.implicitConversions
 
 trait RecordPackageCompat {
-  final opaque type ->>[K, +V] = tagged.TranslucentTagged[V, K]
-  object ->> {
-    implicit def convertToV[K, V](kv: K ->> V): V = kv
+  final opaque type ->>[K, +V] = V
+  sealed trait `->>LP` {
+    @deprecated("Use inlineConvertToV", "0.8.0")
+    private[record] implicit def convertToV[K, V](kv: K ->> V): V = kv
+  }
+  object ->> extends `->>LP` {
+    inline implicit def inlineConvertToV[K, V](kv: K ->> V): V = kv
   }
 
-  @inline final def field[K]: [V] => V => (K ->> V) = [v] => (v: v) => tagged.translucentTag[K](v)
-  @inline final def label[K]: [V] => V => (K ->> V) = [v] => (v: v) => tagged.translucentTag[K](v)
+  @inline final def field[K]: [V] => V => (K ->> V) = [v] => (v: v) => v
+  @inline final def label[K]: [V] => V => (K ->> V) = [v] => (v: v) => v
 
   extension[K <: Singleton](k: K) {
-    inline final def ->>[V](v: V): K ->> V = tagged.translucentTag[K](v)
+    inline final def ->>[V](v: V): K ->> V = v
   }
 
   extension[K, V](kv: K ->> V) {


### PR DESCRIPTION
`V` and `TranslucentTagged[V, K]` are ultimately equivalent, but the former results in less indirection and doesn't require any additional allocations at runtime